### PR TITLE
Fix foreign key relationship PrnStatusHistory => Prn

### DIFF
--- a/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTests.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTests.cs
@@ -200,7 +200,7 @@ public class RepositoryTests
         var result = await _repository.GetPrnsForPrnNumbers([prns[0].PrnNumber, prns[1].PrnNumber]);
 
         result.Count.Should().Be(2);
-        result.Should().BeEquivalentTo([prns[0], prns[1]]);
+        result.Should().BeEquivalentTo([prns[0], prns[1]], o => o.Excluding(prn => prn.PrnStatusHistories));
     }
 
     [TestMethod]

--- a/src/EPR.PRN.Backend.API.UnitTests/Services/PrnServiceTests.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Services/PrnServiceTests.cs
@@ -72,7 +72,7 @@ public class PrnServiceTests
 
         var result = await _systemUnderTest.GetAllPrnByOrganisationId(orgId);
 
-        result.Should().BeEquivalentTo(expectedPrns);
+        result.Should().BeEquivalentTo(expectedPrns, o => o.Excluding(p => p.PrnStatusHistories));
     }
 
     [TestMethod]

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -251,9 +251,11 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
             if (existingPrn == null)
             {
                 newPrn.CreatedOn = currentTimestamp;
+                newPrn.LastUpdatedDate = currentTimestamp;
                 newPrn.ExternalId = Guid.NewGuid();
+                List<PrnStatusHistory> history = [statusHistory];
+                newPrn.PrnStatusHistories = history;
                 _eprContext.Prn.Add(newPrn);
-                statusHistory.PrnIdFk = newPrn.Id;
 
                 logger.LogInformation("Attempting to add new Prn entity with PrnNumber : {PrnNumber}", prnLogVal);
             }
@@ -267,10 +269,10 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
 
                 statusHistory.PrnIdFk = existingPrn.Id;
                 logger.LogInformation("Attempting to update Prn entity with PrnNumber : {PrnNumber} and {Id}", prnLogVal, newPrn?.Id);
-            }
 
-            // Add Prn status history
-            _eprContext.PrnStatusHistory.Add(statusHistory);
+                // Add Prn status history
+                _eprContext.PrnStatusHistory.Add(statusHistory);
+            }
 
             await _eprContext.SaveChangesAsync();
             logger.LogInformation("Prn Entity successfully upserted. PrnNumber : {PrnNumber} and {Id}", prnLogVal, newPrn?.Id);

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -247,7 +247,7 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
 
             var prnLogVal = newPrn.PrnNumber?.Replace(Environment.NewLine, "");
 
-            // Add new PRN entity
+            // Add new PRN
             if (existingPrn == null)
             {
                 newPrn.CreatedOn = currentTimestamp;
@@ -259,7 +259,7 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
 
                 logger.LogInformation("Attempting to add new Prn entity with PrnNumber : {PrnNumber}", prnLogVal);
             }
-            // Update existing PRN entity
+            // Update existing PRN
             else
             {
                 newPrn.Id = existingPrn.Id;

--- a/src/EPR.PRN.Backend.Data/DataModels/EPRN.cs
+++ b/src/EPR.PRN.Backend.Data/DataModels/EPRN.cs
@@ -85,5 +85,7 @@ namespace EPR.PRN.Backend.Data.DataModels
 		public DateTime LastUpdatedDate { get; set; }
 		
 		public bool IsExport { get; set; }
-	}
+
+        public ICollection<PrnStatusHistory> PrnStatusHistories { get; set; } = null!;
+    }
 }

--- a/src/EPR.PRN.Backend.Data/DataModels/EPRN.cs
+++ b/src/EPR.PRN.Backend.Data/DataModels/EPRN.cs
@@ -86,6 +86,6 @@ namespace EPR.PRN.Backend.Data.DataModels
 		
 		public bool IsExport { get; set; }
 
-        public ICollection<PrnStatusHistory> PrnStatusHistories { get; set; } = null!;
+        public virtual ICollection<PrnStatusHistory> PrnStatusHistories { get; set; } = null!;
     }
 }

--- a/src/EPR.PRN.Backend.Data/DataModels/PrnStatusHistory.cs
+++ b/src/EPR.PRN.Backend.Data/DataModels/PrnStatusHistory.cs
@@ -21,5 +21,7 @@ namespace EPR.PRN.Backend.Data.DataModels
 		
 		[MaxLength(1000)]
 		public string? Comment { get; set; }
-	}
+
+        public Eprn Prn { get; set; } = null!;
+    }
 }

--- a/src/EPR.PRN.Backend.Data/DataModels/PrnStatusHistory.cs
+++ b/src/EPR.PRN.Backend.Data/DataModels/PrnStatusHistory.cs
@@ -22,6 +22,6 @@ namespace EPR.PRN.Backend.Data.DataModels
 		[MaxLength(1000)]
 		public string? Comment { get; set; }
 
-        public Eprn Prn { get; set; } = null!;
+        public virtual Eprn Prn { get; set; } = null!;
     }
 }

--- a/src/EPR.PRN.Backend.Data/DataModels/PrnStatusHistory.cs
+++ b/src/EPR.PRN.Backend.Data/DataModels/PrnStatusHistory.cs
@@ -21,7 +21,5 @@ namespace EPR.PRN.Backend.Data.DataModels
 		
 		[MaxLength(1000)]
 		public string? Comment { get; set; }
-
-        public virtual Eprn Prn { get; set; } = null!;
     }
 }

--- a/src/EPR.PRN.Backend.Data/EprContext.cs
+++ b/src/EPR.PRN.Backend.Data/EprContext.cs
@@ -61,12 +61,11 @@ namespace EPR.PRN.Backend.Data
                             new Material { MaterialCode = "GL", MaterialName = "Glass" }
                 );
 
-            modelBuilder.Entity<PrnStatusHistory>(entity =>
+            modelBuilder.Entity<Eprn>(entity =>
             {
-                entity.HasOne(hist => hist.Prn)
-                    .WithMany(prn => prn.PrnStatusHistories)
-                    .HasForeignKey(hist => hist.PrnIdFk)
-                    .OnDelete(DeleteBehavior.NoAction);
+                entity.HasMany(prn => prn.PrnStatusHistories)
+                .WithOne()
+                .HasForeignKey(s => s.PrnIdFk);
             });
 
             base.OnModelCreating(modelBuilder);

--- a/src/EPR.PRN.Backend.Data/EprContext.cs
+++ b/src/EPR.PRN.Backend.Data/EprContext.cs
@@ -61,6 +61,14 @@ namespace EPR.PRN.Backend.Data
                             new Material { MaterialCode = "GL", MaterialName = "Glass" }
                 );
 
+            modelBuilder.Entity<PrnStatusHistory>(entity =>
+            {
+                entity.HasOne(hist => hist.Prn)
+                    .WithMany(prn => prn.PrnStatusHistories)
+                    .HasForeignKey(hist => hist.PrnIdFk)
+                    .OnDelete(DeleteBehavior.NoAction);
+            });
+
             base.OnModelCreating(modelBuilder);
         }
 

--- a/src/EPR.PRN.Backend.Data/Migrations/20250121132037_PrnPrnstatusHistoryRelation.Designer.cs
+++ b/src/EPR.PRN.Backend.Data/Migrations/20250121132037_PrnPrnstatusHistoryRelation.Designer.cs
@@ -4,6 +4,7 @@ using EPR.PRN.Backend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EPR.PRN.Backend.Data.Migrations
 {
     [DbContext(typeof(EprContext))]
-    partial class EprContextModelSnapshot : ModelSnapshot
+    [Migration("20250121132037_PrnPrnstatusHistoryRelation")]
+    partial class PrnPrnstatusHistoryRelation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EPR.PRN.Backend.Data/Migrations/20250121132037_PrnPrnstatusHistoryRelation.cs
+++ b/src/EPR.PRN.Backend.Data/Migrations/20250121132037_PrnPrnstatusHistoryRelation.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EPR.PRN.Backend.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PrnPrnstatusHistoryRelation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PrnStatusHistory_PrnIdFk",
+                table: "PrnStatusHistory",
+                column: "PrnIdFk");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PrnStatusHistory_Prn_PrnIdFk",
+                table: "PrnStatusHistory",
+                column: "PrnIdFk",
+                principalTable: "Prn",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PrnStatusHistory_Prn_PrnIdFk",
+                table: "PrnStatusHistory");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PrnStatusHistory_PrnIdFk",
+                table: "PrnStatusHistory");
+        }
+    }
+}

--- a/src/EPR.PRN.Backend.Data/Scripts/migrations.sql
+++ b/src/EPR.PRN.Backend.Data/Scripts/migrations.sql
@@ -434,3 +434,37 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250121132037_PrnPrnstatusHistoryRelation'
+)
+BEGIN
+    CREATE INDEX [IX_PrnStatusHistory_PrnIdFk] ON [PrnStatusHistory] ([PrnIdFk]);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250121132037_PrnPrnstatusHistoryRelation'
+)
+BEGIN
+    ALTER TABLE [PrnStatusHistory] ADD CONSTRAINT [FK_PrnStatusHistory_Prn_PrnIdFk] FOREIGN KEY ([PrnIdFk]) REFERENCES [Prn] ([Id]) ON DELETE CASCADE;
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250121132037_PrnPrnstatusHistoryRelation'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20250121132037_PrnPrnstatusHistoryRelation', N'8.0.8');
+END;
+GO
+
+COMMIT;
+GO
+


### PR DESCRIPTION
When saving a new Prn, the PrnStatusHistory table was saved with a zero as the foreign key to the Prn, whereas it should be the Id of the new Prn.

Refer to story https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/498609