### PR TITLE
Create relationship Prn and PrnStatusHistory

### DIFF
--- a/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTests.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTests.cs
@@ -200,7 +200,7 @@ public class RepositoryTests
         var result = await _repository.GetPrnsForPrnNumbers([prns[0].PrnNumber, prns[1].PrnNumber]);
 
         result.Count.Should().Be(2);
-        result.Should().BeEquivalentTo([prns[0], prns[1]]);
+        result.Should().BeEquivalentTo([prns[0], prns[1]], o => o.Excluding(prn => prn.PrnStatusHistories));
     }
 
     [TestMethod]

--- a/src/EPR.PRN.Backend.API.UnitTests/Services/PrnServiceTests.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Services/PrnServiceTests.cs
@@ -72,7 +72,7 @@ public class PrnServiceTests
 
         var result = await _systemUnderTest.GetAllPrnByOrganisationId(orgId);
 
-        result.Should().BeEquivalentTo(expectedPrns);
+        result.Should().BeEquivalentTo(expectedPrns, o => o.Excluding(p => p.PrnStatusHistories));
     }
 
     [TestMethod]

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -247,17 +247,19 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
 
             var prnLogVal = newPrn.PrnNumber?.Replace(Environment.NewLine, "");
 
-            // Add new PRN entity
+            // Add new PRN
             if (existingPrn == null)
             {
                 newPrn.CreatedOn = currentTimestamp;
+                newPrn.LastUpdatedDate = currentTimestamp;
                 newPrn.ExternalId = Guid.NewGuid();
+                List<PrnStatusHistory> history = [statusHistory];
+                newPrn.PrnStatusHistories = history;
                 _eprContext.Prn.Add(newPrn);
-                statusHistory.PrnIdFk = newPrn.Id;
 
                 logger.LogInformation("Attempting to add new Prn entity with PrnNumber : {PrnNumber}", prnLogVal);
             }
-            // Update existing PRN entity
+            // Update existing PRN
             else
             {
                 newPrn.Id = existingPrn.Id;
@@ -267,10 +269,10 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
 
                 statusHistory.PrnIdFk = existingPrn.Id;
                 logger.LogInformation("Attempting to update Prn entity with PrnNumber : {PrnNumber} and {Id}", prnLogVal, newPrn?.Id);
-            }
 
-            // Add Prn status history
-            _eprContext.PrnStatusHistory.Add(statusHistory);
+                // Add Prn status history
+                _eprContext.PrnStatusHistory.Add(statusHistory);
+            }
 
             await _eprContext.SaveChangesAsync();
             logger.LogInformation("Prn Entity successfully upserted. PrnNumber : {PrnNumber} and {Id}", prnLogVal, newPrn?.Id);

--- a/src/EPR.PRN.Backend.Data/DataModels/EPRN.cs
+++ b/src/EPR.PRN.Backend.Data/DataModels/EPRN.cs
@@ -85,5 +85,8 @@ namespace EPR.PRN.Backend.Data.DataModels
 		public DateTime LastUpdatedDate { get; set; }
 		
 		public bool IsExport { get; set; }
-	}
+
+		public virtual ICollection<PrnStatusHistory> PrnStatusHistories { get; set; } = null!;
+
+    }
 }

--- a/src/EPR.PRN.Backend.Data/EprContext.cs
+++ b/src/EPR.PRN.Backend.Data/EprContext.cs
@@ -61,6 +61,14 @@ namespace EPR.PRN.Backend.Data
                             new Material { MaterialCode = "GL", MaterialName = "Glass" }
                 );
 
+            modelBuilder.Entity<Eprn>(entity =>
+            {
+                entity.HasMany(prn => prn.PrnStatusHistories)
+                .WithOne()
+                .HasForeignKey(s => s.PrnIdFk)
+                .OnDelete(DeleteBehavior.NoAction);
+            });
+
             base.OnModelCreating(modelBuilder);
         }
 

--- a/src/EPR.PRN.Backend.Data/Migrations/20250121153034_PrnStatusHistoryForeignKeyToPrn.Designer.cs
+++ b/src/EPR.PRN.Backend.Data/Migrations/20250121153034_PrnStatusHistoryForeignKeyToPrn.Designer.cs
@@ -4,6 +4,7 @@ using EPR.PRN.Backend.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EPR.PRN.Backend.Data.Migrations
 {
     [DbContext(typeof(EprContext))]
-    partial class EprContextModelSnapshot : ModelSnapshot
+    [Migration("20250121153034_PrnStatusHistoryForeignKeyToPrn")]
+    partial class PrnStatusHistoryForeignKeyToPrn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/EPR.PRN.Backend.Data/Migrations/20250121153034_PrnStatusHistoryForeignKeyToPrn.cs
+++ b/src/EPR.PRN.Backend.Data/Migrations/20250121153034_PrnStatusHistoryForeignKeyToPrn.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EPR.PRN.Backend.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class PrnStatusHistoryForeignKeyToPrn : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_PrnStatusHistory_PrnIdFk",
+                table: "PrnStatusHistory",
+                column: "PrnIdFk");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PrnStatusHistory_Prn_PrnIdFk",
+                table: "PrnStatusHistory",
+                column: "PrnIdFk",
+                principalTable: "Prn",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PrnStatusHistory_Prn_PrnIdFk",
+                table: "PrnStatusHistory");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PrnStatusHistory_PrnIdFk",
+                table: "PrnStatusHistory");
+        }
+    }
+}

--- a/src/EPR.PRN.Backend.Data/Scripts/migrations.sql
+++ b/src/EPR.PRN.Backend.Data/Scripts/migrations.sql
@@ -434,3 +434,37 @@ GO
 COMMIT;
 GO
 
+BEGIN TRANSACTION;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250121153034_PrnStatusHistoryForeignKeyToPrn'
+)
+BEGIN
+    CREATE INDEX [IX_PrnStatusHistory_PrnIdFk] ON [PrnStatusHistory] ([PrnIdFk]);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250121153034_PrnStatusHistoryForeignKeyToPrn'
+)
+BEGIN
+    ALTER TABLE [PrnStatusHistory] ADD CONSTRAINT [FK_PrnStatusHistory_Prn_PrnIdFk] FOREIGN KEY ([PrnIdFk]) REFERENCES [Prn] ([Id]);
+END;
+GO
+
+IF NOT EXISTS (
+    SELECT * FROM [__EFMigrationsHistory]
+    WHERE [MigrationId] = N'20250121153034_PrnStatusHistoryForeignKeyToPrn'
+)
+BEGIN
+    INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion])
+    VALUES (N'20250121153034_PrnStatusHistoryForeignKeyToPrn', N'8.0.8');
+END;
+GO
+
+COMMIT;
+GO
+


### PR DESCRIPTION
When saving a new Prn, the PrnStatusHistory table was saved with a zero as the foreign key to the Prn, whereas it should be the Id of the new Prn.

Refer to story https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/498609