### PR TITLE
Bugfix/503635 prn createdon empty

### DIFF
--- a/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTestsInMemory.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTestsInMemory.cs
@@ -594,4 +594,91 @@ public class RepositoryTestsInMemory
         savedEnt.ExternalId.Should().Be(updatedEntity.ExternalId);
         updatedEntity.MaterialName.Should().Be("UpdatingMaterial");
     }
+
+    [TestMethod]
+    public async Task SavePrnDetails_InsertsNewPrn_WithCorrectCreateAndUpdateDates()
+    {
+        var statusUpdatedDate = DateTime.UtcNow.AddDays(-2);
+        var dto = new SavePrnDetailsRequest()
+        {
+            AccreditationNo = "ABC",
+            AccreditationYear = 2018,
+            CancelledDate = DateTime.UtcNow.AddDays(-1),
+            DecemberWaste = true,
+            EvidenceMaterial = "Aluminium",
+            EvidenceNo = Guid.NewGuid().ToString(),
+            EvidenceStatusCode = EprnStatus.AWAITINGACCEPTANCE,
+            EvidenceTonnes = 5000,
+            IssueDate = DateTime.UtcNow.AddDays(-5),
+            IssuedByNPWDCode = "NPWD367742",
+            IssuedByOrgName = "ANB",
+            IssuedToEPRId = Guid.NewGuid(),
+            IssuedToNPWDCode = "NPWD557742",
+            IssuedToOrgName = "ZNZ",
+            IssuerNotes = "no notes",
+            IssuerRef = "ANB-1123",
+            MaterialOperationCode = "R-PLA",
+            ObligationYear = 2025,
+            PrnSignatory = "Pat Anderson",
+            PrnSignatoryPosition = "Director",
+            ProducerAgency = "TTL",
+            RecoveryProcessCode = "N11",
+            ReprocessorAgency = "BEX",
+            StatusDate = DateTime.UtcNow.AddDays(-5),
+        };
+
+        var entity = CreateEprnEntityFromDto(dto);
+
+        await _repository.SavePrnDetails(entity);
+
+        var newPrn = await _context.Prn.SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        newPrn.Should().NotBeNull();
+        newPrn.CreatedOn.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
+        newPrn.LastUpdatedDate.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
+    }
+
+    [TestMethod]
+    public async Task SavePrnDetails_UpdatesPrn_WithCorrectCreateAndUpdateDates()
+    {
+        var statusUpdatedDate = DateTime.UtcNow.AddDays(-2);
+        var dto = new SavePrnDetailsRequest()
+        {
+            AccreditationNo = "ABC",
+            AccreditationYear = 2018,
+            CancelledDate = DateTime.UtcNow.AddDays(-1),
+            DecemberWaste = true,
+            EvidenceMaterial = "Aluminium",
+            EvidenceNo = Guid.NewGuid().ToString(),
+            EvidenceStatusCode = EprnStatus.AWAITINGACCEPTANCE,
+            EvidenceTonnes = 5000,
+            IssueDate = DateTime.UtcNow.AddDays(-5),
+            IssuedByNPWDCode = "NPWD367742",
+            IssuedByOrgName = "ANB",
+            IssuedToEPRId = Guid.NewGuid(),
+            IssuedToNPWDCode = "NPWD557742",
+            IssuedToOrgName = "ZNZ",
+            IssuerNotes = "no notes",
+            IssuerRef = "ANB-1123",
+            MaterialOperationCode = "R-PLA",
+            ObligationYear = 2025,
+            PrnSignatory = "Pat Anderson",
+            PrnSignatoryPosition = "Director",
+            ProducerAgency = "TTL",
+            RecoveryProcessCode = "N11",
+            ReprocessorAgency = "BEX",
+            StatusDate = DateTime.UtcNow.AddDays(-5),
+        };
+
+        var entity = CreateEprnEntityFromDto(dto);
+        await _repository.SavePrnDetails(entity);
+
+        var newPrn = await _context.Prn.SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        DateTime createdDate = newPrn.CreatedOn;
+        DateTime updatedDate = newPrn.LastUpdatedDate;
+        await _repository.SavePrnDetails(newPrn);
+
+        var updatedPrn = await _context.Prn.SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        updatedPrn.CreatedOn.Should().Be(createdDate);
+        updatedPrn.LastUpdatedDate.Should().BeAfter(updatedDate);
+    }
 }

--- a/src/EPR.PRN.Backend.API.UnitTests/Services/PrnServiceTests.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Services/PrnServiceTests.cs
@@ -406,7 +406,7 @@ public class PrnServiceTests
 
         prn.CreatedOn.Should().Be(default);
         prn.IssueDate.Should().Be(issuedDate);
-        prn.LastUpdatedDate.Should().Be(statusUpdatedDate);
+        prn.LastUpdatedDate.Should().Be(default);
         prn.StatusUpdatedOn.Should().Be(statusUpdatedDate);
     }
 
@@ -430,7 +430,7 @@ public class PrnServiceTests
 
         prn.CreatedOn.Should().Be(default);
         prn.IssueDate.Should().Be(issuedDate);
-        prn.LastUpdatedDate.Should().Be(statusUpdatedDate);
+        prn.LastUpdatedDate.Should().Be(default);
         prn.StatusUpdatedOn.Should().Be(statusUpdatedDate.AddDays(1));
     }
 

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -261,6 +261,8 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
             // Update existing PRN
             else
             {
+                newPrn.CreatedOn = existingPrn.CreatedOn;
+                newPrn.LastUpdatedDate = currentTimestamp;
                 newPrn.Id = existingPrn.Id;
                 newPrn.ExternalId = existingPrn.ExternalId;
                 _eprContext.Entry(existingPrn).State = EntityState.Modified;

--- a/src/EPR.PRN.Backend.API/Services/PrnService.cs
+++ b/src/EPR.PRN.Backend.API/Services/PrnService.cs
@@ -122,7 +122,6 @@ public class PrnService(IRepository repository, ILogger<PrnService> logger, ICon
                 ProcessToBeUsed = prn.RecoveryProcessCode,
                 ReprocessingSite = string.Empty,
                 StatusUpdatedOn = prn.EvidenceStatusCode == EprnStatus.CANCELLED ? prn.CancelledDate : prn.StatusDate,
-                LastUpdatedDate = prn.StatusDate!.Value,
                 ExternalId = Guid.Empty, // set value in repo when inserting and set to new guid
                 ReprocessorExporterAgency = prn.ReprocessorAgency!,
                 Signature = null,  // Not defined in NPWD to PRN mapping requirements,


### PR DESCRIPTION
If NPWD Prns are fetched more than once, on subsequent runs the CreatedOn date and time is erroneously set to '0001-01-01 00:00:00.0000000'.

Also the LastUpdatedDate was reliant on when the status was last updated, as that might put it before the CreatedOn date.

Refer to bug https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/503635