### PR TITLE
Exclude Prns that have already been updated when selecting Prns

### DIFF
--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -40,6 +40,7 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
                             join ps in _eprContext.PrnStatus on p.PrnStatusId equals ps.Id
                             where p.StatusUpdatedOn >= fromDate && p.StatusUpdatedOn <= toDate
                             && (p.PrnStatusId == 1 || p.PrnStatusId == 2)
+                            && !_eprContext.PEprNpwdSync.Any(s => p.Id == s.PRNId && p.PrnStatusId == s.PRNStatusId)
                             select new
                             {
                                 p.PrnNumber,


### PR DESCRIPTION
Fix for bug that prevents Prns being updated on NPWD because of an error updating a Prn that has already been updated on NPWD.

Refer to bug https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/506903