### PR TITLE
Prevent NPWD Prns awaiting acceptance overwriting accepted and reject…

### DIFF
--- a/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTestsInMemory.cs
+++ b/src/EPR.PRN.Backend.API.UnitTests/Repositories/RepositoryTestsInMemory.cs
@@ -681,4 +681,122 @@ public class RepositoryTestsInMemory
         updatedPrn.CreatedOn.Should().Be(createdDate);
         updatedPrn.LastUpdatedDate.Should().BeAfter(updatedDate);
     }
+
+    [TestMethod]
+    [DataRow(EprnStatus.ACCEPTED)]
+    [DataRow(EprnStatus.CANCELLED)]
+    [DataRow(EprnStatus.REJECTED)]
+    public async Task SavePrnDetails_WhenIncomingPrnIsAwaitingAcceptance_UpdatesPrn_WithOriginalStatus(EprnStatus eOldStatus)
+    {
+        // Arrange
+        var statusUpdatedDate = DateTime.UtcNow.AddDays(-2);
+        var dto = new SavePrnDetailsRequest()
+        {
+            AccreditationNo = "ABC",
+            AccreditationYear = 2018,
+            CancelledDate = DateTime.UtcNow.AddDays(-1),
+            DecemberWaste = true,
+            EvidenceMaterial = "Aluminium",
+            EvidenceNo = Guid.NewGuid().ToString(),
+            EvidenceStatusCode = eOldStatus,
+            EvidenceTonnes = 5000,
+            IssueDate = DateTime.UtcNow.AddDays(-5),
+            IssuedByNPWDCode = "NPWD367742",
+            IssuedByOrgName = "ANB",
+            IssuedToEPRId = Guid.NewGuid(),
+            IssuedToNPWDCode = "NPWD557742",
+            IssuedToOrgName = "ZNZ",
+            IssuerNotes = "no notes",
+            IssuerRef = "ANB-1123",
+            MaterialOperationCode = "R-PLA",
+            ObligationYear = 2025,
+            PrnSignatory = "Pat Anderson",
+            PrnSignatoryPosition = "Director",
+            ProducerAgency = "TTL",
+            RecoveryProcessCode = "N11",
+            ReprocessorAgency = "BEX",
+            StatusDate = DateTime.UtcNow.AddDays(-5),
+        };
+
+        var entity = CreateEprnEntityFromDto(dto);
+        await _repository.SavePrnDetails(entity);
+        _context.SaveChanges();
+
+        var awaitingAcceptancePrn = await _context.Prn.AsNoTracking().SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        awaitingAcceptancePrn.PrnStatusId = (int)EprnStatus.AWAITINGACCEPTANCE;
+
+        // Act
+        await _repository.SavePrnDetails(awaitingAcceptancePrn);
+
+        // Assert
+        var updatedPrn = await _context.Prn.SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        updatedPrn.PrnStatusId.Should().Be((int) eOldStatus);
+
+        _mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => $"{v}".ToString().StartsWith("Resetting status history on")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Once);
+    }
+
+
+    [TestMethod]
+    [DataRow(EprnStatus.ACCEPTED)]
+    [DataRow(EprnStatus.CANCELLED)]
+    [DataRow(EprnStatus.REJECTED)]
+    [DataRow(EprnStatus.AWAITINGACCEPTANCE)]
+    public async Task SavePrnDetails_WhenExistingPrnIsAwaitingAcceptance_UpdatesPrn_WithNewStatus(EprnStatus eNewStatus)
+    {
+        // Arrange
+        var statusUpdatedDate = DateTime.UtcNow.AddDays(-2);
+        var dto = new SavePrnDetailsRequest()
+        {
+            AccreditationNo = "ABC",
+            AccreditationYear = 2018,
+            CancelledDate = DateTime.UtcNow.AddDays(-1),
+            DecemberWaste = true,
+            EvidenceMaterial = "Aluminium",
+            EvidenceNo = Guid.NewGuid().ToString(),
+            EvidenceStatusCode = EprnStatus.AWAITINGACCEPTANCE,
+            EvidenceTonnes = 5000,
+            IssueDate = DateTime.UtcNow.AddDays(-5),
+            IssuedByNPWDCode = "NPWD367742",
+            IssuedByOrgName = "ANB",
+            IssuedToEPRId = Guid.NewGuid(),
+            IssuedToNPWDCode = "NPWD557742",
+            IssuedToOrgName = "ZNZ",
+            IssuerNotes = "no notes",
+            IssuerRef = "ANB-1123",
+            MaterialOperationCode = "R-PLA",
+            ObligationYear = 2025,
+            PrnSignatory = "Pat Anderson",
+            PrnSignatoryPosition = "Director",
+            ProducerAgency = "TTL",
+            RecoveryProcessCode = "N11",
+            ReprocessorAgency = "BEX",
+            StatusDate = DateTime.UtcNow.AddDays(-5),
+        };
+
+        var entity = CreateEprnEntityFromDto(dto);
+        await _repository.SavePrnDetails(entity);
+        _context.SaveChanges();
+
+        var newPrn = await _context.Prn.AsNoTracking().SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        newPrn.PrnStatusId = (int) eNewStatus;
+
+        // Act
+        await _repository.SavePrnDetails(newPrn);
+
+        // Assert
+        var updatedPrn = await _context.Prn.SingleAsync(x => x.PrnNumber == dto.EvidenceNo);
+        updatedPrn.PrnStatusId.Should().Be((int)eNewStatus);
+
+        _mockLogger.Verify(logger => logger.Log(
+            LogLevel.Information,
+            It.IsAny<EventId>(),
+            It.Is<It.IsAnyType>((v, t) => $"{v}".ToString().StartsWith("Resetting status history on")),
+            null,
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()), Times.Never);
+    }
 }

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -290,9 +290,12 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
                 if (newPrn.PrnStatusId != existingPrn.PrnStatusId && newPrn.PrnStatusId == (int)EprnStatus.AWAITINGACCEPTANCE)
                 {
                     string incomingStatus = ((EprnStatus)newPrn.PrnStatusId).ToString();
+
+                    // put back status and status date in Prn
                     newPrn.PrnStatusId = existingPrn.PrnStatusId;
                     newPrn.StatusUpdatedOn = existingPrn.StatusUpdatedOn;
                     
+                    // put back status in status history
                     statusHistory.PrnStatusIdFk = newPrn.PrnStatusId;
                     statusHistory.Comment = $"{incomingStatus} => {((EprnStatus)newPrn.PrnStatusId).ToString()}";
 

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -291,6 +291,8 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
                 {
                     string incomingStatus = ((EprnStatus)newPrn.PrnStatusId).ToString();
                     newPrn.PrnStatusId = existingPrn.PrnStatusId;
+                    newPrn.StatusUpdatedOn = existingPrn.StatusUpdatedOn;
+                    
                     statusHistory.PrnStatusIdFk = newPrn.PrnStatusId;
                     statusHistory.Comment = $"{incomingStatus} => {((EprnStatus)newPrn.PrnStatusId).ToString()}";
 

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -291,6 +291,7 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
                 {
                     string incomingStatus = ((EprnStatus)newPrn.PrnStatusId).ToString();
                     newPrn.PrnStatusId = existingPrn.PrnStatusId;
+                    statusHistory.PrnStatusIdFk = newPrn.PrnStatusId;
                     statusHistory.Comment = $"{incomingStatus} => {((EprnStatus)newPrn.PrnStatusId).ToString()}";
 
                     logger.LogInformation("Resetting status history on {PrnNumber}: {Msg}", prnLogVal, statusHistory.Comment);

--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -286,6 +286,16 @@ public class Repository(EprContext eprContext, ILogger<Repository> logger, IConf
             // Update existing PRN
             else
             {
+                // the Prn has already been accepted or rejected
+                if (newPrn.PrnStatusId != existingPrn.PrnStatusId && newPrn.PrnStatusId == (int)EprnStatus.AWAITINGACCEPTANCE)
+                {
+                    string incomingStatus = ((EprnStatus)newPrn.PrnStatusId).ToString();
+                    newPrn.PrnStatusId = existingPrn.PrnStatusId;
+                    statusHistory.Comment = $"{incomingStatus} => {((EprnStatus)newPrn.PrnStatusId).ToString()}";
+
+                    logger.LogInformation("Resetting status history on {PrnNumber}: {Msg}", prnLogVal, statusHistory.Comment);
+                }
+
                 newPrn.CreatedOn = existingPrn.CreatedOn;
                 newPrn.LastUpdatedDate = currentTimestamp;
                 newPrn.Id = existingPrn.Id;


### PR DESCRIPTION
Prevent NPWD Prns awaiting acceptance overwriting accepted and rejected Prns. After a Prn has been accepted or rejected, if the Prn comes in somehow from NPWD with a status of awaiting acceptance, the status of the Prn must not be updated although other fields such as tonnage should be.

Refer to bug https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/507212