### PR TITLE
Match material names

### DIFF
--- a/src/EPR.PRN.Backend.Obligation.UnitTests/Mappers/MaterialsMapperTests.cs
+++ b/src/EPR.PRN.Backend.Obligation.UnitTests/Mappers/MaterialsMapperTests.cs
@@ -1,0 +1,22 @@
+﻿using FluentAssertions;
+
+namespace EPR.PRN.Backend.Obligation.UnitTests.Mappers;
+
+[TestClass]
+public class MaterialsMapperTests
+{
+    [TestMethod]
+    [DataRow("Aluminium", "Aluminium")]
+    [DataRow("Glass Other", "Glass")]
+    [DataRow("Glass Re-melt", "GlassRemelt")]
+    [DataRow("Paper/board", "Paper")]
+    [DataRow("Plastic", "Plastic")]
+    [DataRow("Steel", "Steel")]
+    [DataRow("Wood", "Wood")]
+    public void MapMaterialName_Returns_Adjusted_MaterialName(string rawMaterial, string expectedMaterial)
+    {
+        string actualMaterial = EPR.PRN.Backend.Obligation.Mappers.MaterialsMapper.MapMaterialName(rawMaterial);
+
+        actualMaterial.Should().Be(expectedMaterial);
+    }
+}

--- a/src/EPR.PRN.Backend.Obligation/Mappers/MaterialsMapper.cs
+++ b/src/EPR.PRN.Backend.Obligation/Mappers/MaterialsMapper.cs
@@ -1,0 +1,34 @@
+﻿using EPR.PRN.Backend.Data.DTO;
+
+namespace EPR.PRN.Backend.Obligation.Mappers;
+
+public static class MaterialsMapper
+{
+
+    public static IQueryable<EprnResultsDto> AdjustPrnMaterialNames(IQueryable<EprnResultsDto> prns)
+    {
+        List<EprnResultsDto> prnsWithAdjustedMaterialNames = [];
+        foreach (var p in prns)
+        {
+            p.Eprn.MaterialName = MaterialsMapper.MapMaterialName(p.Eprn.MaterialName);
+            prnsWithAdjustedMaterialNames.Add(p);
+        }
+        return prnsWithAdjustedMaterialNames.AsQueryable();
+    }
+
+    // the material names must match those on the material table
+    public static string MapMaterialName(string materialName)
+    {
+        switch (materialName)
+        {
+            case "Glass Other":
+                return "Glass";
+            case "Glass Re-melt":
+                return "GlassRemelt";
+            case "Paper/board":
+                return "Paper";
+            default:
+                return materialName;
+        }
+    }
+}

--- a/src/EPR.PRN.Backend.Obligation/Services/ObligationCalculatorService.cs
+++ b/src/EPR.PRN.Backend.Obligation/Services/ObligationCalculatorService.cs
@@ -116,6 +116,10 @@ namespace EPR.PRN.Backend.Obligation.Services
             var materialsWithRemelt = AddGlassRemelt(materials.ToList());
             var obligationCalculations = await _obligationCalculationRepository.GetObligationCalculation(organisationId, year);
             var prns = _prnRepository.GetAcceptedAndAwaitingPrnsByYear(organisationId, year);
+
+            // make sure material names match materials table
+            prns = Mappers.MaterialsMapper.AdjustPrnMaterialNames(prns);
+
             var acceptedTonnageForPrns = GetSumOfTonnageForMaterials(prns, EprnStatus.ACCEPTED.ToString());
             var awaitingAcceptanceForPrns = GetSumOfTonnageForMaterials(prns, EprnStatus.AWAITINGACCEPTANCE.ToString());
             var awaitingAcceptanceCount = GetPrnStatusCount(prns, EprnStatus.AWAITINGACCEPTANCE.ToString());


### PR DESCRIPTION
Tonnage was not showing on obligations pages because the material name on the Prn did not match that on the Material table.

Refer to https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_workitems/edit/508274