### PR TITLE
Bringing sprint 18 up to date with main

### DIFF
--- a/pipelines/vars/prod.yaml
+++ b/pipelines/vars/prod.yaml
@@ -7,4 +7,4 @@ variables:
   kvName: PRDRWDINFKV1401
   sqlDBserver: 'prdrwddbssq1401.database.windows.net'
   sqlDB: 'prd1_prn'
-  acr.Subscription: 'AZD-RWD-PRD1'
+  acr.Subscription: 'AZR-RWD-PRD1'


### PR DESCRIPTION
* syncing release 8 changes into 81 (#175)

* Exclude Prns that have already been updated when selecting Prns to send to NPWD (#171)



* Prevent NPWD Prns awaiting acceptance overwriting accepted and reject… (#173)

* Prevent NPWD Prns awaiting acceptance overwriting accepted and rejected Prns

---------



---------




* Map Prn material to matching value in Material table (#176) (#179)




* prod yaml file change missing from r81

---------