### PR TITLE
Added in code to reset the permit tonnage details 

### DIFF
--- a/src/EPR.PRN.Backend.Data.UnitTests/Repositories/Regulator/RegistrationMaterialRepositoryTests.cs
+++ b/src/EPR.PRN.Backend.Data.UnitTests/Repositories/Regulator/RegistrationMaterialRepositoryTests.cs
@@ -6,8 +6,6 @@ using EPR.PRN.Backend.Data.Repositories.Regulator;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.EntityFrameworkCore;
-using System.Configuration;
-using System.Threading.Tasks;
 
 namespace EPR.PRN.Backend.Data.UnitTests.Repositories.Regulator;
 
@@ -802,7 +800,52 @@ public class RegistrationMaterialRepositoryTests
     }
 
     [TestMethod]
-    [DataRow(1, "")] 
+    public async Task UpdateRegistrationMaterialPermits_WasteExemptions_ShouldUpdate_WhenExists()
+    {
+        // Arrange
+        var registrationMaterialId = Guid.Parse("a9421fc1-a912-42ee-85a5-3e06408759a9");
+        var exemptions = new List<MaterialExemptionReference>
+        {
+            new()
+            {
+                ReferenceNo = "1234",
+                RegistrationMaterialId = 1
+            },
+            new()
+            {
+                ReferenceNo = "5678",
+                RegistrationMaterialId = 1
+            }
+        };
+
+        var expected = new List<MaterialExemptionReference>();
+        expected.AddRange(exemptions);
+        expected.Add(new MaterialExemptionReference
+        {
+            Id = 1,
+            ReferenceNo = "EXEMPT123",
+            RegistrationMaterialId = 1
+        });
+
+        _context.MaterialExemptionReferences.AddRange(exemptions);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _repository.UpdateRegistrationMaterialPermits(registrationMaterialId, (int)MaterialPermitType.WasteExemption, null);
+        var registrationMaterial = await _context.RegistrationMaterials.FirstOrDefaultAsync(x => x.ExternalId == registrationMaterialId);
+
+        // Assert
+        registrationMaterial.PermitTypeId.Should().Be((int)MaterialPermitType.WasteExemption);
+        registrationMaterial.EnvironmentalPermitWasteManagementNumber.Should().BeNull();
+        registrationMaterial.WasteManagementLicenceNumber.Should().BeNull();
+        registrationMaterial.InstallationPermitNumber.Should().BeNull();
+        registrationMaterial.PPCPermitNumber.Should().BeNull();
+
+        var loaded = _context.MaterialExemptionReferences.Where(o => o.RegistrationMaterialId == 1).ToList();
+        loaded.Should().BeEquivalentTo(expected, o => o.Excluding(x => x.RegistrationMaterial));
+    }
+
+    [TestMethod]
     [DataRow(2, "PPC-123")]
     [DataRow(3, "WML-123")]
     [DataRow(4, "IP-123")]
@@ -811,6 +854,22 @@ public class RegistrationMaterialRepositoryTests
     {
         // Arrange
         var registrationMaterialId = Guid.Parse("a9421fc1-a912-42ee-85a5-3e06408759a9");
+        var exemptions = new List<MaterialExemptionReference>
+        {
+            new()
+            {
+                ReferenceNo = "1234",
+                RegistrationMaterialId = 1
+            },
+            new()
+            {
+                ReferenceNo = "5678",
+                RegistrationMaterialId = 1
+            }
+        };
+
+        _context.MaterialExemptionReferences.AddRange(exemptions);
+        await _context.SaveChangesAsync();
 
         // Act
         await _repository.UpdateRegistrationMaterialPermits(registrationMaterialId, permitTypeId, permitNumber);
@@ -823,17 +882,32 @@ public class RegistrationMaterialRepositoryTests
         {
             case MaterialPermitType.PollutionPreventionAndControlPermit:
                 registrationMaterial.PPCPermitNumber.Should().Be(permitNumber);
+                registrationMaterial.WasteManagementLicenceNumber.Should().BeNull();
+                registrationMaterial.InstallationPermitNumber.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber.Should().BeNull();
                 break;
             case MaterialPermitType.WasteManagementLicence:
                 registrationMaterial.WasteManagementLicenceNumber.Should().Be(permitNumber);
+                registrationMaterial.PPCPermitNumber.Should().BeNull();
+                registrationMaterial.InstallationPermitNumber.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber.Should().BeNull();
                 break;
             case MaterialPermitType.InstallationPermit:
                 registrationMaterial.InstallationPermitNumber.Should().Be(permitNumber);
+                registrationMaterial.WasteManagementLicenceNumber.Should().BeNull();
+                registrationMaterial.PPCPermitNumber.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber.Should().BeNull();
                 break;
             case MaterialPermitType.EnvironmentalPermitOrWasteManagementLicence:
                 registrationMaterial.EnvironmentalPermitWasteManagementNumber.Should().Be(permitNumber);
+                registrationMaterial.WasteManagementLicenceNumber.Should().BeNull();
+                registrationMaterial.InstallationPermitNumber.Should().BeNull();
+                registrationMaterial.PPCPermitNumber.Should().BeNull();
                 break;
         }
+
+        var loaded = _context.MaterialExemptionReferences.Where(o => o.RegistrationMaterialId == 1).ToList();
+        loaded.Should().BeEmpty();
     }
 
     [DataTestMethod]
@@ -857,18 +931,42 @@ public class RegistrationMaterialRepositoryTests
             case MaterialPermitType.PollutionPreventionAndControlPermit:
                 registrationMaterial.PPCReprocessingCapacityTonne.Should().Be(capacityInTonnesAsDecimal);
                 registrationMaterial.PPCPeriodId.Should().Be(periodId);
+                registrationMaterial.WasteManagementReprocessingCapacityTonne.Should().BeNull();
+                registrationMaterial.WasteManagementPeriodId.Should().BeNull();
+                registrationMaterial.InstallationReprocessingTonne.Should().BeNull();
+                registrationMaterial.InstallationPeriodId.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementPeriodId.Should().BeNull();
                 break;
             case MaterialPermitType.WasteManagementLicence:
                 registrationMaterial.WasteManagementReprocessingCapacityTonne.Should().Be(capacityInTonnesAsDecimal);
                 registrationMaterial.WasteManagementPeriodId.Should().Be(periodId);
+                registrationMaterial.PPCReprocessingCapacityTonne.Should().BeNull();
+                registrationMaterial.PPCPeriodId.Should().BeNull();
+                registrationMaterial.InstallationReprocessingTonne.Should().BeNull();
+                registrationMaterial.InstallationPeriodId.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementPeriodId.Should().BeNull();
                 break;
             case MaterialPermitType.InstallationPermit:
                 registrationMaterial.InstallationReprocessingTonne.Should().Be(capacityInTonnesAsDecimal);
                 registrationMaterial.InstallationPeriodId.Should().Be(periodId);
+                registrationMaterial.WasteManagementReprocessingCapacityTonne.Should().BeNull();
+                registrationMaterial.WasteManagementPeriodId.Should().BeNull();
+                registrationMaterial.PPCReprocessingCapacityTonne.Should().BeNull();
+                registrationMaterial.PPCPeriodId.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne.Should().BeNull();
+                registrationMaterial.EnvironmentalPermitWasteManagementPeriodId.Should().BeNull();
                 break;
             case MaterialPermitType.EnvironmentalPermitOrWasteManagementLicence:
                 registrationMaterial.EnvironmentalPermitWasteManagementTonne.Should().Be(capacityInTonnesAsDecimal);
                 registrationMaterial.EnvironmentalPermitWasteManagementPeriodId.Should().Be(periodId);
+                registrationMaterial.WasteManagementReprocessingCapacityTonne.Should().BeNull();
+                registrationMaterial.WasteManagementPeriodId.Should().BeNull();
+                registrationMaterial.InstallationReprocessingTonne.Should().BeNull();
+                registrationMaterial.InstallationPeriodId.Should().BeNull();
+                registrationMaterial.PPCReprocessingCapacityTonne.Should().BeNull();
+                registrationMaterial.PPCPeriodId.Should().BeNull();
                 break;
         }
     }

--- a/src/EPR.PRN.Backend.Data/Repositories/Regulator/RegistrationMaterialRepository.cs
+++ b/src/EPR.PRN.Backend.Data/Repositories/Regulator/RegistrationMaterialRepository.cs
@@ -233,25 +233,48 @@ public class RegistrationMaterialRepository(EprContext eprContext) : IRegistrati
     public async Task UpdateRegistrationMaterialPermits(Guid registrationMaterialId, int permitTypeId, string? permitNumber)
     {
         var registrationMaterial = await eprContext.RegistrationMaterials
-                                        .FirstOrDefaultAsync(rm => rm.ExternalId == registrationMaterialId) ?? throw new KeyNotFoundException("Material not found.");
+            .FirstOrDefaultAsync(rm => rm.ExternalId == registrationMaterialId) ?? throw new KeyNotFoundException("Material not found.");
 
         // Permit Type Id
         registrationMaterial.PermitTypeId = permitTypeId;
+
+        if ((MaterialPermitType)permitTypeId is not MaterialPermitType.WasteExemption)
+        {
+           eprContext.MaterialExemptionReferences.RemoveRange(eprContext.MaterialExemptionReferences.Where(o => o.RegistrationMaterialId == registrationMaterial.Id).ToList());
+        }
 
         // Permit Number
         switch ((MaterialPermitType)permitTypeId)
         {
             case MaterialPermitType.PollutionPreventionAndControlPermit:
                 registrationMaterial.PPCPermitNumber = permitNumber;
+                registrationMaterial.InstallationPermitNumber = null;
+                registrationMaterial.WasteManagementLicenceNumber = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber = null;
                 break;
             case MaterialPermitType.WasteManagementLicence:
                 registrationMaterial.WasteManagementLicenceNumber = permitNumber;
+                registrationMaterial.InstallationPermitNumber = null;
+                registrationMaterial.PPCPermitNumber = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber = null;
                 break;
             case MaterialPermitType.InstallationPermit:
                 registrationMaterial.InstallationPermitNumber = permitNumber;
+                registrationMaterial.PPCPermitNumber = null;
+                registrationMaterial.WasteManagementLicenceNumber = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber = null;
                 break;
             case MaterialPermitType.EnvironmentalPermitOrWasteManagementLicence:
                 registrationMaterial.EnvironmentalPermitWasteManagementNumber = permitNumber;
+                registrationMaterial.InstallationPermitNumber = null;
+                registrationMaterial.WasteManagementLicenceNumber = null;
+                registrationMaterial.PPCPermitNumber = null;
+                break;
+            case MaterialPermitType.WasteExemption:
+                registrationMaterial.EnvironmentalPermitWasteManagementNumber = null;
+                registrationMaterial.InstallationPermitNumber = null;
+                registrationMaterial.WasteManagementLicenceNumber = null;
+                registrationMaterial.PPCPermitNumber = null;
                 break;
         }
 
@@ -261,26 +284,50 @@ public class RegistrationMaterialRepository(EprContext eprContext) : IRegistrati
     public async Task UpdateRegistrationMaterialPermitCapacity(Guid registrationMaterialId, int permitTypeId, decimal? capacityInTonnes, int? periodId)
     {
         var registrationMaterial = await eprContext.RegistrationMaterials
-                                        .FirstOrDefaultAsync(rm => rm.ExternalId == registrationMaterialId) ?? throw new KeyNotFoundException("Material not found.");
+            .FirstOrDefaultAsync(rm => rm.ExternalId == registrationMaterialId) ?? throw new KeyNotFoundException("Material not found.");
 
         // Capacity in tonnes and period Ids
         switch ((MaterialPermitType)permitTypeId)
         {
             case MaterialPermitType.PollutionPreventionAndControlPermit:
-                registrationMaterial.PPCReprocessingCapacityTonne = capacityInTonnes ?? 0;
+                registrationMaterial.PPCReprocessingCapacityTonne = capacityInTonnes;
                 registrationMaterial.PPCPeriodId = periodId;
+                registrationMaterial.WasteManagementReprocessingCapacityTonne = null;
+                registrationMaterial.WasteManagementPeriodId = null;
+                registrationMaterial.InstallationReprocessingTonne = null;
+                registrationMaterial.InstallationPeriodId = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementPeriodId = null;
                 break;
             case MaterialPermitType.WasteManagementLicence:
-                registrationMaterial.WasteManagementReprocessingCapacityTonne = capacityInTonnes ?? 0;
+                registrationMaterial.WasteManagementReprocessingCapacityTonne = capacityInTonnes;
                 registrationMaterial.WasteManagementPeriodId = periodId;
+                registrationMaterial.PPCReprocessingCapacityTonne = null;
+                registrationMaterial.PPCPeriodId = null;
+                registrationMaterial.InstallationReprocessingTonne = null;
+                registrationMaterial.InstallationPeriodId = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementPeriodId = null;
                 break;
             case MaterialPermitType.InstallationPermit:
-                registrationMaterial.InstallationReprocessingTonne = capacityInTonnes ?? 0;
+                registrationMaterial.InstallationReprocessingTonne = capacityInTonnes;
                 registrationMaterial.InstallationPeriodId = periodId;
+                registrationMaterial.WasteManagementReprocessingCapacityTonne = null;
+                registrationMaterial.WasteManagementPeriodId = null;
+                registrationMaterial.PPCReprocessingCapacityTonne = null;
+                registrationMaterial.PPCPeriodId = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne = null;
+                registrationMaterial.EnvironmentalPermitWasteManagementPeriodId = null;
                 break;
             case MaterialPermitType.EnvironmentalPermitOrWasteManagementLicence:
-                registrationMaterial.EnvironmentalPermitWasteManagementTonne = capacityInTonnes ?? 0;
+                registrationMaterial.EnvironmentalPermitWasteManagementTonne = capacityInTonnes;
                 registrationMaterial.EnvironmentalPermitWasteManagementPeriodId = periodId;
+                registrationMaterial.WasteManagementReprocessingCapacityTonne = null;
+                registrationMaterial.WasteManagementPeriodId = null;
+                registrationMaterial.InstallationReprocessingTonne = null;
+                registrationMaterial.InstallationPeriodId = null;
+                registrationMaterial.PPCReprocessingCapacityTonne = null;
+                registrationMaterial.PPCPeriodId = null;
                 break;
         }
 


### PR DESCRIPTION
- When changing permit types, we now reset the tonnage details so we dont end up with multiple permit type details filled in at the same time if the user chooses to change the permit type