### PR TITLE
Changed to use string.IsNullOrEmpty

### DIFF
--- a/src/EPR.PRN.Backend.Obligation/Services/ObligationCalculatorService.cs
+++ b/src/EPR.PRN.Backend.Obligation/Services/ObligationCalculatorService.cs
@@ -8,7 +8,6 @@ using EPR.PRN.Backend.Obligation.Helpers;
 using EPR.PRN.Backend.Obligation.Interfaces;
 using EPR.PRN.Backend.Obligation.Models;
 using Microsoft.Extensions.Logging;
-using Microsoft.IdentityModel.Tokens;
 
 namespace EPR.PRN.Backend.Obligation.Services
 {
@@ -76,9 +75,9 @@ namespace EPR.PRN.Backend.Obligation.Services
 		{
 			submitterTypeName = default;
 
-			var submitterType = request.Find(r => !r.SubmitterType.IsNullOrEmpty())?.SubmitterType;
+			var submitterType = request.Find(r => !string.IsNullOrEmpty(r.SubmitterType))?.SubmitterType;
 
-			return !submitterType.IsNullOrEmpty() &&
+			return !string.IsNullOrEmpty(submitterType) &&
 				Enum.TryParse(request[0].SubmitterType, true, out submitterTypeName);
 		}
 
@@ -99,7 +98,7 @@ namespace EPR.PRN.Backend.Obligation.Services
 
 			var materialName = materials.FirstOrDefault(m => m.MaterialCode == submission.PackagingMaterial)?.MaterialName;
 
-			if (materialName.IsNullOrEmpty() || !Enum.TryParse(materialName, true, out materialType))
+			if (string.IsNullOrEmpty(materialName) || !Enum.TryParse(materialName, true, out materialType))
 			{
 				logger.LogError("Material provided was not valid: {PackagingMaterial} for OrganisationId: {OrganisationId} and SubmitterId: {SubmitterId}.",
 					submission.PackagingMaterial, submission.OrganisationId, submitterId);


### PR DESCRIPTION
Changed to use string.IsNullOrEmpty as the previous version, whilst it worked for a time, now suddenly breaks, but this is the right approach regardless to use the string class version of the extension method.