### PR TITLE
MO-115: Switch to MagicMapper to avoid CVE security vulnerability in AutoMapper

### DIFF
--- a/src/EPR.PRN.Backend.API/EPR.PRN.Backend.API.csproj
+++ b/src/EPR.PRN.Backend.API/EPR.PRN.Backend.API.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="8.0.2" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
-    <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="MagicMapper" Version="14.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.16.0" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />

--- a/src/EPR.PRN.Backend.Data/EPR.PRN.Backend.Data.csproj
+++ b/src/EPR.PRN.Backend.Data/EPR.PRN.Backend.Data.csproj
@@ -11,7 +11,7 @@
 		<Exec Condition="$(Configuration) == Release" Command="dotnet-ef migrations script --configuration Release --verbose --no-build --context EPR.PRN.Backend.Data.EprContext --idempotent --output Scripts/migrations.sql" />
 	</Target>
 	<ItemGroup>
-		<PackageReference Include="AutoMapper" Version="14.0.0" />
+		<PackageReference Include="MagicMapper" Version="14.0.1" />
 		<PackageReference Include="Azure.Identity" Version="1.16.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.20" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.20">


### PR DESCRIPTION
As per PR title.

MagicMapper is a community fork of AutoMapper and has the CVE security vulnerability fixed. The use of AutoMapper in the PRN API is extensive and therefore replacing the mapping code in full would introduce too much change.

MagicMapper retains the MIT license.