### PR TITLE
MO-130: Manual update of deps to avoid image push error based on length of dependabot branch name

### DIFF
--- a/src/EPR.PRN.Backend.API.UnitTests/EPR.PRN.Backend.API.UnitTests.csproj
+++ b/src/EPR.PRN.Backend.API.UnitTests/EPR.PRN.Backend.API.UnitTests.csproj
@@ -18,7 +18,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.26" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="Moq" Version="4.20.72" />
 		<PackageReference Include="Moq.EntityFrameworkCore" Version="8.0.1.7" />
 		<PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />

--- a/src/EPR.PRN.Backend.API/EPR.PRN.Backend.API.csproj
+++ b/src/EPR.PRN.Backend.API/EPR.PRN.Backend.API.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.26" />
     <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.4" />

--- a/src/EPR.PRN.Backend.Data.UnitTests/EPR.PRN.Backend.Data.UnitTests.csproj
+++ b/src/EPR.PRN.Backend.Data.UnitTests/EPR.PRN.Backend.Data.UnitTests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.26" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.26" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Moq.EntityFrameworkCore" Version="8.0.1.7" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />

--- a/src/EPR.PRN.Backend.Obligation.UnitTests/EPR.PRN.Backend.Obligation.UnitTests.csproj
+++ b/src/EPR.PRN.Backend.Obligation.UnitTests/EPR.PRN.Backend.Obligation.UnitTests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.26" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.2" />
     <PackageReference Include="System.Formats.Asn1" Version="8.0.2" />


### PR DESCRIPTION
As per PR title.