### PR TITLE
SUB-300: Sets the default build value of the AzureBuild flag

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <AzureBuild Condition="'$(AzureBuild)' == ''">true</AzureBuild>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
The "AfterBuild" event in the Data project fires if the AzureBuild flag is set to false. The upgrades to .NET 10 surfaced a long standing bug in the global CI build templates where builds were being built in DEBUG configuration (the @dotnetcli2 build task default) because of an unset pipeline parameter. This is now set with a default of "RELEASE" as a matter of best practice when running CI builds and this meant the SQL migration task is being run by CI builds and then fails as the EF Core tools are not present on the build agents.

Simplest fix is to add this Directory.Build.props file to set the default value of the flag for all builds, allowing docker builds to continue to explicitly set the flag to false where the migrations are required.