### PR TITLE
MO-354: Remove logging of IQueryable as it will materialise the query too early

### DIFF
--- a/src/EPR.PRN.Backend.API/Repositories/Repository.cs
+++ b/src/EPR.PRN.Backend.API/Repositories/Repository.cs
@@ -33,9 +33,9 @@ public class Repository(
         );
         var prns = _eprContext.Prn.Where(x => x.OrganisationId == orgId);
         logger.LogInformation(
-            "{Logprefix}: PrnService - GetAllPrnsForOrganisation: Prns fetched {Prns}",
+            "{Logprefix}: Repository - GetAllPrnsForOrganisation: PRN query prepared for organisation {Organisation}",
             logPrefix,
-            JsonConvert.SerializeObject(prns)
+            orgId
         );
         return prns;
     }
@@ -49,7 +49,7 @@ public class Repository(
         );
         var prns = await GetAllPrnsForOrganisation(orgId).ToListAsync();
         logger.LogInformation(
-            "{Logprefix}: PrnService - GetAllPrnByOrganisationId: Prns fetched {Prns}",
+            "{Logprefix}: Repository - GetAllPrnByOrganisationId: Prns fetched {Prns}",
             logPrefix,
             JsonConvert.SerializeObject(prns)
         );
@@ -298,10 +298,9 @@ public class Repository(
         );
         var prns = GetAllPrnsForOrganisation(orgId);
         logger.LogInformation(
-            "{Logprefix}: Repository - GetSearchPrnsForOrganisation: GetAllPrnsForOrganisation for Organisation: {OrgId}, Fetched: {PaginatedRequest}",
+            "{Logprefix}: Repository - GetSearchPrnsForOrganisation: GetAllPrnsForOrganisation query prepared for Organisation: {OrgId}",
             logPrefix,
-            orgId,
-            JsonConvert.SerializeObject(prns)
+            orgId
         );
 
         var prnNumbers = prns.Select(prn => prn.PrnNumber)
@@ -569,7 +568,7 @@ public class Repository(
         {
             logger.LogError(
                 exception: ex,
-                "{Logprefix}: Error Message: {Message}",
+                "{Logprefix}: Repository - SavePrnDetails: Error Message: {Message}",
                 logPrefix,
                 ex.Message
             );


### PR DESCRIPTION
Small fix that prevents execution of SQL - logging the collection when it's an IQueryable will materialise the list and exec the SQL, only for the IQueryable to be reused and then it will query again.

This will be causing a small performance hit when requesting PRNs by organisation, but for larger organisations with more PRNs, it might be having a more noticeable impact.